### PR TITLE
Fix linking - undefined reference to celif

### DIFF
--- a/makefile
+++ b/makefile
@@ -27,7 +27,7 @@ ifdef DZCOMM
    EXT = .exe
 else
    DEFINES += -DTERMIOS
-   LIBS = $(AL_LIBS)
+   LIBS = $(AL_LIBS) -lm
    EXT =
 endif
 endif


### PR DESCRIPTION
The build fails on several arches in Debian:

```
gcc -O2 -g -Wall -Werror -DTERMIOS -c main.c
gcc -O2 -g -Wall -Werror -DTERMIOS -c main_menu.c
gcc -O2 -g -Wall -Werror -DTERMIOS -c serial.c
gcc -O2 -g -Wall -Werror -DTERMIOS -c options.c
gcc -O2 -g -Wall -Werror -DTERMIOS -c sensors.c
gcc -O2 -g -Wall -Werror -DTERMIOS -c trouble_code_reader.c
gcc -O2 -g -Wall -Werror -DTERMIOS -c custom_gui.c
gcc -O2 -g -Wall -Werror -DTERMIOS -c error_handlers.c
gcc -O2 -g -Wall -Werror -DTERMIOS -c about.c
gcc -O2 -g -Wall -Werror -DTERMIOS -c reset.c
gcc -O2 -g -Wall -Werror -DTERMIOS -o scantool main.o main_menu.o serial.o options.o sensors.o trouble_code_reader.o custom_gui.o error_handlers.o about.o reset.o  -L/usr/lib/i386-linux-gnu -lalleg
/usr/bin/ld: trouble_code_reader.o: undefined reference to symbol 'ceilf@@GLIBC_2.0'
/usr/bin/ld: /lib/i386-linux-gnu/libm.so.6: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make: *** [makefile:56: scantool] Error 
```

Adding linking with -lm fixes it.