### PR TITLE
Check that allegro subsystem is ready

### DIFF
--- a/main.c
+++ b/main.c
@@ -72,7 +72,8 @@ static void init()
    
    /* initialize hardware */
    write_log("Initializing Allegro... ");
-   allegro_init();
+   if (allegro_init() != 0)
+      fatal_error("Cannot initialize the graphical subsystem. Check DISPLAY variable.");
    write_log("OK\n");
    
    set_window_title(WINDOW_TITLE);


### PR DESCRIPTION
Adding a check that the Allegro subsystem is ready.

Generally, `allegro_init()` fails if the DISPLAY variable is not correctly set.