### PR TITLE
Pseudo-tty support

### DIFF
--- a/main.c
+++ b/main.c
@@ -168,7 +168,10 @@ static void init()
    serial_module_init();
    write_log("OK\n");
 
-   sprintf(temp_buf, "Opening COM%i... ", comport.number + 1);
+   if (comport.number >= 1000)
+      sprintf(temp_buf, "Opening PTS%i... ", comport.number - 1000);
+   else
+      sprintf(temp_buf, "Opening COM%i... ", comport.number + 1);
    write_log(temp_buf);
    /* try opening comport (comport.status will be set) */
    open_comport();

--- a/sensors.c
+++ b/sensors.c
@@ -784,14 +784,25 @@ int status_proc(int msg, DIALOG *d, int c)
          
             if (comport.status == READY)
             {
-               if (device_connected)
-                  sprintf(d->dp, " COM%i ready (device connected)", comport.number + 1);
-               else
-                  sprintf(d->dp, " COM%i ready (device not found)", comport.number + 1);
+               if (device_connected) {
+                  if (comport.number >= 1000)
+                     sprintf(d->dp, " PTS%i ready (device connected)", comport.number - 1000);
+                  else
+                     sprintf(d->dp, " COM%i ready (device connected)", comport.number + 1);
+               } else {
+                  if (comport.number >= 1000)
+                     sprintf(d->dp, " PTS%i ready (device not found)", comport.number - 1000);
+                  else
+                     sprintf(d->dp, " COM%i ready (device not found)", comport.number + 1);
+               }
             }
-            else
-               sprintf(d->dp, " COM%i could not be opened", comport.number + 1);
-         
+            else {
+               if (comport.number >= 1000)
+                  sprintf(d->dp, " PTS%i could not be opened", comport.number - 1000);
+               else
+                  sprintf(d->dp, " COM%i could not be opened", comport.number + 1);
+               }
+
             return D_REDRAWME;
          }
    }

--- a/serial.c
+++ b/serial.c
@@ -99,7 +99,11 @@ int open_comport()
    // Naming of serial ports 10 and higher: See
    // http://www.connecttech.com/KnowledgeDatabase/kdb227.htm
    // http://support.microsoft.com/?id=115831
-   sprintf(temp_str, "\\\\.\\COM%i", comport.number + 1);
+   if (comport.number >= 1000) {
+      sprintf(temp_str, "\\\\.\\PTS%i", comport.number - 1000);
+   }
+   else
+      sprintf(temp_str, "\\\\.\\COM%i", comport.number + 1);
    com_port = CreateFile(temp_str, GENERIC_READ | GENERIC_WRITE, 0, 0, OPEN_EXISTING, 0, 0);
    if (com_port == INVALID_HANDLE_VALUE)
    {
@@ -152,10 +156,16 @@ int open_comport()
    }
 #elif TERMIOS
     char tmp[54];
-    if( comport.number < 100 )
-        snprintf(tmp, sizeof(tmp), "/dev/ttyS%d", comport.number);
-    else
-        snprintf(tmp, sizeof(tmp), "/dev/ttyUSB%d", comport.number-100);
+    if (comport.number >= 1000) {
+        snprintf(tmp, sizeof(tmp), "/dev/pts/%d", comport.number - 1000);
+        printf("Using port %s\n", tmp);
+    }
+    else {
+      if (comport.number < 100)
+          snprintf(tmp, sizeof(tmp), "/dev/ttyS%d", comport.number);
+      else
+          snprintf(tmp, sizeof(tmp), "/dev/ttyUSB%d", comport.number - 100);
+    }
     fdtty = open( tmp, O_RDWR | O_NOCTTY );
     if (fdtty <0) { return(-1); }
 


### PR DESCRIPTION
To use a pseudo-tty as COM port, edit *~/.scantoolrc* and add the line `comport_number = ` *1000 + pty number*; for instance, for */dev/pts/3*, set the following in *~/.scantoolrc*:

```ini
[comm]
comport_number = 1003
```

Note: when setting a pseudo-tty, only use *~/.scantoolrc* and do not edit the serial port through the *"Options"* panel of the user interface.