### PR TITLE
Debug and Log compilation options

### DIFF
--- a/makefile
+++ b/makefile
@@ -3,7 +3,6 @@ AL_LIBS = $(shell allegro-config --libs)
 CFLAGS ?= -O2 -Wall
 
 ifdef DEBUGMODE
-   DEFINES = -DDEBUG
    CFLAGS += -g
    $(info ************  DEBUG OPTION ENABLED ************)
 else

--- a/makefile
+++ b/makefile
@@ -1,9 +1,11 @@
 CC = gcc
 AL_LIBS = $(shell allegro-config --libs)
-CFLAGS ?= -O2 -g -Wall
+CFLAGS ?= -O2 -Wall
 
 ifdef DEBUGMODE
    DEFINES = -DDEBUG
+   CFLAGS += -g
+   $(info ************  DEBUG OPTION ENABLED ************)
 else
 ifdef RELEASE
    CFLAGS += -O3 -fexpensive-optimizations -s
@@ -34,6 +36,11 @@ endif
 
 ifndef NOWERROR
    CFLAGS += -Werror
+endif
+
+ifdef LOG
+   DEFINES += -DLOG_COMMS
+   $(info ************  LOG OPTION ENABLED ************)
 endif
 
 ifdef DEFINES


### PR DESCRIPTION
# Debug and Log compilation options

Revised *makefile*, moving the `-g` option to DEBUGMODE and allowing the LOG option.

## Compilation

To perform a standard compilation, set the *RELEASE* flag to *YES*. Check the following example, which also includes prerequisites:

```bash
sudo apt install -y liballegro4.4 liballegro4-dev allegro4-doc
make clean
make -e RELEASE=yes
```

### Enabling logging

In order to enable logging to a file named *"comm_log.txt"* in the current directory, set the *LOG* compilation flag to *YES*, like in the following example:

```bash
make clean
make -e RELEASE=yes LOG=yes
```

### Compilation in DEBUG mode

To compile in debug mode, set the *DEBUGMODE* compilation flag to *YES* instead of using the *RELEASE* flag, like in the following example, which also includes logging to *"comm_log.txt"*:

```bash
make clean
make -e DEBUGMODE=yes LOG=yes
```